### PR TITLE
add check for no requiring docstring if the overload decorator is pre…

### DIFF
--- a/src/docstringify/nodes/base.py
+++ b/src/docstringify/nodes/base.py
@@ -33,7 +33,7 @@ class DocstringNode:
     ) -> None:
         self.module_name: str = module_name
         self.parent: DocstringNode | None = parent
-        self.docstring_required: bool = True
+        self._docstring_required: bool = True
 
         self.ast_node: (
             ast.Module | ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef
@@ -53,4 +53,27 @@ class DocstringNode:
             f'{self.parent.fully_qualified_name}.{self.name}'
             if self.parent
             else self.name
+        )
+
+    @property
+    def docstring_required(self) -> bool:
+        if self._has_decorator('overload'):
+            return False
+        return self._docstring_required
+
+    @docstring_required.setter
+    def docstring_required(self, value: bool) -> None:
+        self._docstring_required = value
+
+    def _has_decorator(self, decorator_name: str) -> bool:
+        if not hasattr(self.ast_node, 'decorator_list'):
+            return False
+
+        return any(
+            (isinstance(decorator, ast.Name) and decorator.id == decorator_name)
+            or (
+                isinstance(decorator, ast.Attribute)
+                and decorator.attr == decorator_name
+            )
+            for decorator in self.ast_node.decorator_list
         )


### PR DESCRIPTION
<!-- Which issue does this address? -->
Fixes #13 

**Describe your changes**
- Added functionality to check if a node requires a docstring by leveraging the `_has_decorator` method from the `DocstringNode` class. This ensures that nodes decorated with specific decorators, such as `@overload`, are correctly identified and excluded from the `docstring_required` check. 

<!-- TODO -->

**Checklist**

<!-- Place an X between the [ ] for completed tasks -->

- [ ] Test cases have been modified/added to cover any code changes.
- [ ] Docstrings have been modified/created for any code changes.
- [ ] All linting and formatting checks pass (see the [contributing guidelines](https://github.com/stefmolin/docstringify/blob/main/CONTRIBUTING.md) for more information).
