### PR TITLE
Preserve comments, spacing, and style in the code when using `--make-changes` and `--make-changes-inplace`

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,19 @@ test.say_hello is missing a docstring
 Docstring templates written to /.../test_docstringify.py
 ```
 
-If you want to overwrite the file with the edits, pass `overwrite=True` to `DocstringTransformer()`.
+If you want to overwrite the file with the edits, pass `overwrite=True` to `DocstringTransformer()`:
+
+```pycon
+>>> from docstringify.converters import GoogleDocstringConverter
+>>> from docstringify.traversal import DocstringTransformer
+>>> transformer = DocstringTransformer(
+...     'test.py', converter=GoogleDocstringConverter, overwrite=True
+... )
+>>> transformer.process_file()
+test is missing a docstring
+test.say_hello is missing a docstring
+Docstring templates written to /.../test.py
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You can use Docstringify in three modes:
 
 ### Pre-commit hook
 
-Add the following to your `.pre-commit-config.yaml` file to block commits with missing docstrings:
+Add the following to your `.pre-commit-config.yaml` file to block commits with missing docstrings before any formatters like `ruff`:
 
 ```yaml
 - repo: https://github.com/stefmolin/docstringify

--- a/src/docstringify/converters/base.py
+++ b/src/docstringify/converters/base.py
@@ -184,7 +184,9 @@ class DocstringConverter(ABC):
             return self._returns_section_template.format(returns=return_text)
         return ''
 
-    def format_docstring(self, docstring: str | list[str], indent: int) -> str:
+    def format_docstring(
+        self, docstring: str | list[str], indent: int, quote: bool | None = None
+    ) -> str:
         """
         Format the docstring with the requested level of indentation and surrounding
         triple quotes, if requested.
@@ -195,23 +197,32 @@ class DocstringConverter(ABC):
             The docstring as a string or list of strings that form lines in the docstring.
         indent : int
             The number of spaces by which to indent the docstring.
+        quote : bool, optional
+            Whether to quote the docstring, passing this overrides the ``quote`` setting
+            specified upon initialization.
 
         Returns
         -------
         str
             The docstring indented to ``indent`` spaces will be returned either as a
-            quoted docstring if the converter was initialized with ``quote=True``, or an
-            unquoted docstring otherwise.
+            quoted docstring if the converter was initialized with ``quote=True`` or
+            ``quote=True`` was passed when calling this method, or an unquoted
+            docstring otherwise.
         """
-        quote = '"""' if self._quote else ''
+        quote_char = '"""' if quote or self._quote else ''
         prefix = sep = ''
+
         if isinstance(docstring, str):
-            docstring = [quote, docstring, quote]
+            docstring = [quote_char, docstring, quote_char]
         elif isinstance(docstring, list):
             if len(docstring) > 1:
                 prefix = ' ' * indent if indent else ''
                 sep = '\n'
-            docstring = [quote, *docstring, f'{prefix}{quote}']
+            docstring = [
+                quote_char,
+                *docstring,
+                quote_char if quote_char else f'{prefix}',
+            ]
         else:
             raise InvalidDocstringError(type(docstring).__name__)
 

--- a/src/docstringify/converters/base.py
+++ b/src/docstringify/converters/base.py
@@ -218,11 +218,7 @@ class DocstringConverter(ABC):
             if len(docstring) > 1:
                 prefix = ' ' * indent if indent else ''
                 sep = '\n'
-            docstring = [
-                quote_char,
-                *docstring,
-                quote_char if quote_char else f'{prefix}',
-            ]
+            docstring = [quote_char, *docstring, quote_char or f'{prefix}']
         else:
             raise InvalidDocstringError(type(docstring).__name__)
 

--- a/src/docstringify/converters/base.py
+++ b/src/docstringify/converters/base.py
@@ -197,9 +197,9 @@ class DocstringConverter(ABC):
             The docstring as a string or list of strings that form lines in the docstring.
         indent : int
             The number of spaces by which to indent the docstring.
-        quote : bool, optional
-            Whether to quote the docstring, passing this overrides the ``quote`` setting
-            specified upon initialization.
+        quote : bool | None, default=None
+            Whether to surround the docstring in triple quotes, passing this overrides
+            the ``quote`` setting specified upon initialization.
 
         Returns
         -------

--- a/src/docstringify/exceptions.py
+++ b/src/docstringify/exceptions.py
@@ -1,6 +1,25 @@
 """Docstringify exceptions."""
 
 
-class InvalidDocstringError(ValueError):
+class EmptyDocstringError(ValueError):
+    """
+    Raised when trying to write the modified source code back to a file if a docstring
+    is somehow empty.
+    """
+
+    def __init__(self) -> None:
+        super().__init__('Docstring is empty')
+
+
+class InvalidDocstringError(TypeError):
+    """
+    Raised when trying to create a docstring with invalid input.
+
+    Parameters
+    ----------
+    docstring_class : str
+        The class of the docstring object. This is used for the error message.
+    """
+
     def __init__(self, docstring_class: str) -> None:
         super().__init__(f'Expected str or list[str] docstring, got {docstring_class}')

--- a/src/docstringify/nodes/function.py
+++ b/src/docstringify/nodes/function.py
@@ -62,7 +62,9 @@ class FunctionDocstringNode(DocstringNode):
             and not self.is_overload
         )
 
-        self.arguments: ast.arguments | None = getattr(node, 'args', None)
+        self.arguments: ast.arguments = node.args
+
+        self.returns: ast.AST | None = node.returns
         self.return_annotation: str | None = self._extract_return_annotation()
         self.return_statements: list[ast.Return] = []
 
@@ -172,23 +174,28 @@ class FunctionDocstringNode(DocstringNode):
         return params
 
     def _extract_return_annotation(self) -> str | None:
-        if return_annotation_node := self.ast_node.returns:
-            if isinstance(return_annotation_node, ast.Constant):
-                return return_annotation_node.value
-            if isinstance(return_annotation_node, ast.Name):
-                return return_annotation_node.id
-            return self.get_source_segment(return_annotation_node)
-        return None
+        if self.returns is None:
+            return self.returns
+
+        if isinstance(self.returns, ast.Constant):
+            return self.returns.value
+
+        if isinstance(self.returns, ast.Name):
+            return self.returns.id
+
+        return self.get_source_segment(self.returns)
 
     def extract_returns(self) -> str | None:
         if self.return_annotation:
             return self.return_annotation
+
         if any(
             not isinstance((return_value := return_node.value), ast.Constant)
             or return_value.value
             for return_node in self.return_statements
         ):
             return RETURN_TYPE_PLACEHOLDER
+
         return None
 
     def to_function(self) -> Function:

--- a/src/docstringify/nodes/function.py
+++ b/src/docstringify/nodes/function.py
@@ -25,9 +25,14 @@ class FunctionDocstringNode(DocstringNode):
         super().__init__(node, module_name, source_code, parent)
 
         self.decorators: list[str] = [
-            self.get_source_segment(decorator) for decorator in node.decorator_list
+            decorator
+            for decorator_node in node.decorator_list
+            if (decorator := self.get_source_segment(decorator_node))
         ]
 
+        self.is_overload: bool = (
+            'overload' in self.decorators or 'typing.overload' in self.decorators
+        )
         self.is_method: bool = self.parent is not None and isinstance(
             self.parent.ast_node, ast.ClassDef
         )
@@ -46,8 +51,15 @@ class FunctionDocstringNode(DocstringNode):
         )
 
         # don't require docstring for the __init__ method if the class has a docstring
-        self.docstring_required: bool = not (
-            self.is_method and self.name == '__init__' and self.parent.docstring
+        # or if the function/method is just a typing.overload signature
+        self.docstring_required: bool = (
+            not (
+                self.is_method
+                and self.name == '__init__'
+                and self.parent is not None
+                and self.parent.docstring
+            )
+            and not self.is_overload
         )
 
         self.arguments: ast.arguments | None = getattr(node, 'args', None)

--- a/src/docstringify/nodes/function.py
+++ b/src/docstringify/nodes/function.py
@@ -39,7 +39,9 @@ class FunctionDocstringNode(DocstringNode):
             self.is_method and 'staticmethod' in self.decorators
         )
         self.is_instance_method: bool = (
-            self.is_method and not self.is_class_method and not self.is_static_method
+            self.is_method
+            and (not self.is_class_method)
+            and (not self.is_static_method)
         )
 
         # don't require docstring for the __init__ method if the class has a docstring

--- a/src/docstringify/nodes/function.py
+++ b/src/docstringify/nodes/function.py
@@ -64,7 +64,8 @@ class FunctionDocstringNode(DocstringNode):
 
             return (
                 f'"{default_value}"'
-                if isinstance(default_value, str) and not default_value.startswith('`')
+                if isinstance(default_value, str)
+                and (not default_value.startswith('`'))
                 else default_value
             )
         return NO_DEFAULT
@@ -95,8 +96,9 @@ class FunctionDocstringNode(DocstringNode):
 
     def _extract_positional_args(self) -> list[Parameter]:
         if (default_count := len(positional_defaults := self.arguments.defaults)) < (
-            positional_arguments_count := len(self.arguments.posonlyargs)
-            + len(self.arguments.args)
+            positional_arguments_count := (
+                len(self.arguments.posonlyargs) + len(self.arguments.args)
+            )
         ):
             positional_defaults = [NO_DEFAULT] * (
                 positional_arguments_count - default_count
@@ -167,7 +169,7 @@ class FunctionDocstringNode(DocstringNode):
         if self.return_annotation:
             return self.return_annotation
         if any(
-            not isinstance(return_value := return_node.value, ast.Constant)
+            not isinstance((return_value := return_node.value), ast.Constant)
             or return_value.value
             for return_node in self.return_statements
         ):

--- a/src/docstringify/traversal/transformer.py
+++ b/src/docstringify/traversal/transformer.py
@@ -9,6 +9,7 @@ import ast
 from textwrap import indent
 from typing import TYPE_CHECKING
 
+from ..exceptions import EmptyDocstringError
 from .visitor import DocstringVisitor
 
 if TYPE_CHECKING:
@@ -113,7 +114,7 @@ class DocstringTransformer(ast.NodeTransformer, DocstringVisitor):
 
             # write docstring
             if not (docstring := missing_docstring.docstring):
-                raise ValueError('Docstring is empty')
+                raise EmptyDocstringError
 
             output_lines.append(
                 indent(

--- a/src/docstringify/traversal/transformer.py
+++ b/src/docstringify/traversal/transformer.py
@@ -6,6 +6,7 @@ on the source code.
 from __future__ import annotations
 
 import ast
+from textwrap import indent
 from typing import TYPE_CHECKING
 
 from .visitor import DocstringVisitor
@@ -65,6 +66,15 @@ class DocstringTransformer(ast.NodeTransformer, DocstringVisitor):
             print(f'Docstring templates written to {output}')
 
     def _convert_to_source_code(self) -> str:
+        """
+        Convert the modified AST back to source code, preserving the original format and
+        any comments.
+
+        Returns
+        -------
+        str
+            The original source code with the docstrings injected.
+        """
         source_code = self.source_code.splitlines()
         output_lines = []
         write_line = 0
@@ -102,10 +112,21 @@ class DocstringTransformer(ast.NodeTransformer, DocstringVisitor):
             output_lines += source_code[write_line:start_line]
 
             # write docstring
-            output_lines += [
-                f'{" " * prefix}"""{missing_docstring.raw_docstring}"""'
-                + (f'\n{" " * prefix}{suffix}' if suffix else '')
-            ]
+            if not (docstring := missing_docstring.docstring):
+                raise ValueError('Docstring is empty')
+
+            output_lines.append(
+                indent(
+                    self.docstring_converter.format_docstring(
+                        docstring.splitlines(),
+                        indent=0,
+                        quote=True,
+                    )
+                    + (f'\n{suffix}' if suffix else ''),
+                    ' ' * prefix,
+                )
+            )
+
             write_line = start_line
 
         output_lines += source_code[write_line:]

--- a/src/docstringify/traversal/transformer.py
+++ b/src/docstringify/traversal/transformer.py
@@ -112,7 +112,7 @@ class DocstringTransformer(ast.NodeTransformer, DocstringVisitor):
 
         return '\n'.join(output_lines) + '\n'
 
-    def handle_missing_docstring(self, docstring_node: DocstringNode) -> DocstringNode:
+    def handle_missing_docstring(self, docstring_node: DocstringNode) -> None:
         """
         Handle missing docstrings by injecting a suggested docstring template based on
         the source code into the AST.
@@ -122,13 +122,6 @@ class DocstringTransformer(ast.NodeTransformer, DocstringVisitor):
         docstring_node : DocstringNode
             An instance of :class:`.DocstringNode`, which wraps an AST node and adds
             additional context relevant for Docstringify.
-
-        Returns
-        -------
-        DocstringNode
-            An instance of :class:`.DocstringNode`, which wraps an AST node and adds
-            additional context relevant for Docstringify. The AST node it contains will
-            have a new node for the docstring template added to its body.
         """
         suggested_docstring = self.docstring_converter.suggest_docstring(
             docstring_node,
@@ -146,8 +139,6 @@ class DocstringTransformer(ast.NodeTransformer, DocstringVisitor):
             docstring_node.ast_node.body.insert(0, docstring_ast_node)
 
         docstring_node.ast_node = ast.fix_missing_locations(docstring_node.ast_node)
-
-        return docstring_node
 
     def process_file(self) -> None:
         """

--- a/src/docstringify/traversal/transformer.py
+++ b/src/docstringify/traversal/transformer.py
@@ -60,9 +60,57 @@ class DocstringTransformer(ast.NodeTransformer, DocstringVisitor):
                     + ''.join(self.source_file.suffixes)
                 )
             )
-            edited_code = ast.unparse(self.tree)
+            edited_code = self._convert_to_source_code()
             output.write_text(edited_code)
             print(f'Docstring templates written to {output}')
+
+    def _convert_to_source_code(self) -> str:
+        source_code = self.source_code.splitlines()
+        output_lines = []
+        write_line = 0
+
+        for missing_docstring in self.missing_docstrings:
+            # write everything before docstring
+            if isinstance(missing_docstring.ast_node, ast.Module):
+                prefix = start_line = 0
+                suffix = ''
+            else:
+                docstring_node = missing_docstring.ast_node.body[0]
+                prefix = docstring_node.col_offset + 4
+                suffix = ''
+
+                start_line = missing_docstring.ast_node.body[1].lineno - 1
+                if isinstance(missing_docstring.ast_node, ast.ClassDef):
+                    start_line -= 1
+
+                if len(body := missing_docstring.ast_node.body) == 2:
+                    code_node = body[1]
+                    line_number = code_node.lineno - 1
+                    line = source_code[line_number]
+
+                    if line.strip() != (function_body := line[code_node.col_offset :]):
+                        # if the function body is on the same line as the signature, cut it out
+                        # in order to inject the docstring in the right spot
+                        source_code[line_number] = source_code[line_number][
+                            : code_node.col_offset
+                        ].rstrip()
+
+                        # add the logic under the docstring
+                        start_line = missing_docstring.ast_node.body[1].lineno
+                        suffix = function_body
+
+            output_lines += source_code[write_line:start_line]
+
+            # write docstring
+            output_lines += [
+                f'{" " * prefix}"""{missing_docstring.raw_docstring}"""'
+                + (f'\n{" " * prefix}{suffix}' if suffix else '')
+            ]
+            write_line = start_line
+
+        output_lines += source_code[write_line:]
+
+        return '\n'.join(output_lines) + '\n'
 
     def handle_missing_docstring(self, docstring_node: DocstringNode) -> DocstringNode:
         """

--- a/src/docstringify/traversal/transformer.py
+++ b/src/docstringify/traversal/transformer.py
@@ -78,18 +78,15 @@ class DocstringTransformer(ast.NodeTransformer, DocstringVisitor):
         """
         source_code = self.source_code.splitlines()
         output_lines = []
-        write_line = 0
+        write_line = start_line = 0
 
         for missing_docstring in self.missing_docstrings:
-            # write everything before docstring
-            if isinstance(missing_docstring.ast_node, ast.Module):
-                prefix = start_line = 0
-                suffix = ''
-            else:
-                docstring_node = missing_docstring.ast_node.body[0]
-                prefix = docstring_node.col_offset + 4
-                suffix = ''
+            docstring_node = missing_docstring.ast_node.body[0]
+            prefix = docstring_node.col_offset
+            suffix = ''
 
+            # write everything before docstring
+            if not isinstance(missing_docstring.ast_node, ast.Module):
                 start_line = missing_docstring.ast_node.body[1].lineno - 1
                 if isinstance(missing_docstring.ast_node, ast.ClassDef):
                     start_line -= 1
@@ -128,8 +125,10 @@ class DocstringTransformer(ast.NodeTransformer, DocstringVisitor):
                 )
             )
 
+            # update current location in file
             write_line = start_line
 
+        # write the rest of the file
         output_lines += source_code[write_line:]
 
         return '\n'.join(output_lines) + '\n'
@@ -145,11 +144,15 @@ class DocstringTransformer(ast.NodeTransformer, DocstringVisitor):
             An instance of :class:`.DocstringNode`, which wraps an AST node and adds
             additional context relevant for Docstringify.
         """
+        indent = (
+            0
+            if isinstance(docstring_node.ast_node, ast.Module)
+            else docstring_node.ast_node.col_offset + 4
+        )
+
         suggested_docstring = self.docstring_converter.suggest_docstring(
             docstring_node,
-            indent=0
-            if isinstance(docstring_node.ast_node, ast.Module)
-            else docstring_node.ast_node.col_offset + 4,
+            indent=indent,
         )
         docstring_ast_node = ast.Expr(ast.Constant(suggested_docstring))
 
@@ -161,6 +164,7 @@ class DocstringTransformer(ast.NodeTransformer, DocstringVisitor):
             docstring_node.ast_node.body.insert(0, docstring_ast_node)
 
         docstring_node.ast_node = ast.fix_missing_locations(docstring_node.ast_node)
+        docstring_ast_node.col_offset = indent
 
     def process_file(self) -> None:
         """

--- a/src/docstringify/traversal/transformer.py
+++ b/src/docstringify/traversal/transformer.py
@@ -87,9 +87,11 @@ class DocstringTransformer(ast.NodeTransformer, DocstringVisitor):
 
             # write everything before docstring
             if not isinstance(missing_docstring.ast_node, ast.Module):
+                # line before a code node
                 start_line = missing_docstring.ast_node.body[1].lineno - 1
+
                 if isinstance(missing_docstring.ast_node, ast.ClassDef):
-                    start_line -= 1
+                    start_line = docstring_node.lineno
 
                 if len(body := missing_docstring.ast_node.body) == 2:
                     code_node = body[1]

--- a/src/docstringify/traversal/visitor.py
+++ b/src/docstringify/traversal/visitor.py
@@ -112,8 +112,8 @@ class DocstringVisitor(ast.NodeVisitor):
 
     def process_docstring(self, docstring_node: DocstringNode) -> DocstringNode:
         """
-        Process a docstring node, appending it to :attr:`.missing_docstrings` if a docstring
-        is required, but there isn't one.
+        Process a docstring node, appending it to :attr:`.missing_docstrings` if a
+        docstring is required, but there isn't one.
 
         Parameters
         ----------
@@ -181,12 +181,12 @@ class DocstringVisitor(ast.NodeVisitor):
         ast.AsyncFunctionDef | ast.ClassDef | ast.FunctionDef | ast.Module
             The AST node that was visited.
         """
-        docstring_node = docstring_class(
-            node,
-            self.module_name,
-            self.source_code,
-            parent=self.stack[-1] if self.stack else None,
-        )
+        if isinstance(node, ast.Module):
+            docstring_node = docstring_class(node, self.module_name, self.source_code)
+        else:
+            docstring_node = docstring_class(
+                node, self.module_name, self.source_code, parent=self.stack[-1]
+            )
 
         self.stack.append(docstring_node)
 


### PR DESCRIPTION
Fixes #5, #33, and #13

This PR changes the logic in the `DocstringTransformer` that converts the AST back to source code to use custom logic to write the file instead of unparsing the AST, since the AST does not preserve comments, styling, etc.