### PR TITLE
Fix file rewrites for the edge case of empty docstrings that need to be replaced with templates

### DIFF
--- a/src/docstringify/nodes/base.py
+++ b/src/docstringify/nodes/base.py
@@ -70,6 +70,15 @@ class DocstringNode:
         )
         """Callable to get the source code for the AST node (:attr:`.ast_node`)."""
 
+        self.original_docstring_location: tuple[int, int] | None = (
+            None
+            if self.docstring is None
+            else (self.ast_node.body[0].lineno, self.ast_node.body[0].end_lineno)
+        )
+        """Start and end line of the docstring in the original file, if there was one,
+        otherwise, ``None``. This is necessary for the rewriting algorithm to exclude
+        these lines from the file."""
+
     @property
     def docstring(self) -> str | None:
         """

--- a/src/docstringify/traversal/transformer.py
+++ b/src/docstringify/traversal/transformer.py
@@ -79,6 +79,7 @@ class DocstringTransformer(ast.NodeTransformer, DocstringVisitor):
         source_code = self.source_code.splitlines()
         output_lines = []
         write_line = start_line = 0
+        skip_lines = None
 
         for missing_docstring in self.missing_docstrings:
             docstring_node = missing_docstring.ast_node.body[0]
@@ -89,6 +90,7 @@ class DocstringTransformer(ast.NodeTransformer, DocstringVisitor):
             if not isinstance(missing_docstring.ast_node, ast.Module):
                 # line before a code node
                 start_line = missing_docstring.ast_node.body[1].lineno - 1
+                skip_lines = missing_docstring.original_docstring_location
 
                 if isinstance(missing_docstring.ast_node, ast.ClassDef):
                     start_line = docstring_node.lineno
@@ -109,7 +111,14 @@ class DocstringTransformer(ast.NodeTransformer, DocstringVisitor):
                         start_line = missing_docstring.ast_node.body[1].lineno
                         suffix = function_body
 
-            output_lines += source_code[write_line:start_line]
+            if skip_lines:
+                # need to skip over the empty docstring in the original file
+                output_lines += (
+                    source_code[write_line : skip_lines[0] - 1]
+                    + source_code[skip_lines[1] + 1 : start_line]
+                )
+            else:
+                output_lines += source_code[write_line:start_line]
 
             # write docstring
             if not (docstring := missing_docstring.docstring):


### PR DESCRIPTION
Fixes #60 

**Describe your changes**

- Capture start and end lines of empty docstrings in order to exclude them in the file rewrite
- Account for lines that need to be skipped on file rewrites

**Checklist**

<!-- Place an X between the [ ] for completed tasks -->

- [x] Docstrings have been modified/created for any code changes.
- [x] All linting and formatting checks pass (see the [contributing guidelines](https://github.com/stefmolin/docstringify/blob/main/CONTRIBUTING.md) for more information).
