### PR TITLE
Refactor CLI to use subcommands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,5 +65,12 @@ jobs:
       - name: Install dev dependencies
         run: python -m pip install --group dev
 
-      - name: Validate pre-commit hooks
-        run: pre-commit try-repo .
+      - name: Check that the docstringify-edit pre-commit hook is available
+        run: pre-commit try-repo . docstringify-edit
+
+      - name: Check that the docstringify-suggest pre-commit hook is available
+        run: pre-commit try-repo . docstringify-suggest
+
+      # this is the only hook that works without an additional arg so we can test it like this
+      - name: Validate the docstringify-check pre-commit hook
+        run: pre-commit try-repo . docstringify-check --all-files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,5 +65,5 @@ jobs:
       - name: Install dev dependencies
         run: python -m pip install --group dev
 
-      - name: Validate pre-commit hook
-        run: pre-commit try-repo . docstringify
+      - name: Validate pre-commit hooks
+        run: pre-commit try-repo .

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,5 +1,30 @@
+- id: docstringify-edit
+  name: generate missing docstrings with docstringify
+  description: |
+    Generate missing docstrings from signatures and type annotations, injecting them into the source code.
+  entry: docstringify edit
+  language: python
+  types: [python]
+
+- id: docstringify-suggest
+  name: suggest docstrings with docstringify
+  description: |
+    Generate suggestions for missing docstrings from signatures and type annotations.
+  entry: docstringify suggest
+  language: python
+  types: [python]
+
+- id: docstringify-check
+  name: check for missing docstrings with docstringify
+  description: |
+    Flag missing docstrings failing if more than the threshold are missing.
+  entry: docstringify check
+  language: python
+  require_serial: true
+  types: [python]
+
 - id: docstringify
-  name: docstringify
+  name: docstringify (deprecated)
   description: |
     Flag missing docstrings and, optionally, generate them from signatures and type annotations.
   entry: docstringify

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,13 +20,11 @@ license-files = [ "LICENSE" ]
 authors = [
   { name = "Stefanie Molin", email = "docstringify@stefaniemolin.com" },
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",

--- a/src/docstringify/cli.py
+++ b/src/docstringify/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+from enum import StrEnum, auto
 from functools import partial
 from typing import TYPE_CHECKING
 
@@ -34,6 +35,188 @@ STYLES: dict[
 CLI_DEFAULTS = {'threshold': 1.0}
 
 
+class DocstringifyRunModes(StrEnum):
+    """Run modes for Docstringify's CLI."""
+
+    CHECK = auto()
+    EDIT = auto()
+    SUGGEST = auto()
+
+
+def _process_files(
+    mode: DocstringifyRunModes, args: argparse.Namespace
+) -> tuple[int, int]:
+    """
+    Process the filenames passed in as command line arguments.
+
+    Parameters
+    ----------
+    mode : DocstringifyRunModes
+        The mode in which to run Docstringify.
+    args : argparse.Namespace
+        The command line arguments.
+
+    Returns
+    -------
+    tuple[int, int]
+        A tuple containing the number of missing docstrings and the total number of
+        docstrings expected.
+    """
+    get_docstring_processor = (
+        partial(
+            DocstringTransformer,
+            converter=STYLES[args.style],
+            overwrite=bool(args.overwrite),
+            verbose=args.verbose,
+        )
+        if mode == DocstringifyRunModes.EDIT
+        else partial(
+            DocstringVisitor,
+            converter=None
+            if mode == DocstringifyRunModes.CHECK
+            else STYLES[args.style],
+            verbose=args.verbose,
+        )
+    )
+
+    docstrings_expected = missing_docstrings = 0
+    for file in args.filenames:
+        processor = get_docstring_processor(file)
+        processor.process_file()
+        missing_docstrings += len(processor.missing_docstrings)
+        docstrings_expected += processor.docstrings_inspected
+
+    return missing_docstrings, docstrings_expected
+
+
+def _run(mode: DocstringifyRunModes, args: argparse.Namespace) -> int:
+    """
+    Run Docstringify in the specified mode with the provided command line arguments.
+
+    Parameters
+    ----------
+    mode : DocstringifyRunModes
+        The run mode.
+    args : argparse.Namespace
+        The command line arguments.
+
+    Returns
+    -------
+    int
+        Exit code for the process, where non-zero values indicate errors.
+    """
+    missing_docstrings, docstrings_expected = _process_files(mode, args)
+
+    if mode == DocstringifyRunModes.CHECK:
+        if (
+            docstrings_expected
+            and (missing_percentage := (missing_docstrings / docstrings_expected))
+            > 1 - args.threshold
+        ):
+            print(f'Missing {missing_percentage:.0%} of docstrings', file=sys.stderr)
+            print(
+                f'Your settings require {args.threshold:.0%} of docstrings to be present',
+                file=sys.stderr,
+            )
+            return 1
+        return 0
+
+    # modes suggest and edit behave the same
+    if docstrings_expected and missing_docstrings:
+        return 1
+    return 0
+
+
+def _populate_subparser(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+    subcommand: DocstringifyRunModes,
+    help_msg: str,
+) -> argparse.ArgumentParser:
+    """
+    Populate an argument subparser for handling subcommands from the main CLI.
+
+    Parameters
+    ----------
+    subparsers : argparse._SubParsersAction[argparse.ArgumentParser]
+        The result of calling the :meth:`argparse.ArgumentParser.add_subparsers` method
+        on the main argument parser.
+    subcommand : DocstringifyRunModes
+        The run mode for which to populate the parser.
+    help_msg : str
+        The help message to include for the subcommand.
+
+    Returns
+    -------
+    argparse.ArgumentParser
+        The populated subparser.
+    """
+    parser = subparsers.add_parser(subcommand, help=help_msg)
+
+    parser.add_argument(
+        'filenames', nargs='+', metavar='filename', help='filename(s) to process'
+    )
+
+    if subcommand == DocstringifyRunModes.CHECK:
+        parser.add_argument(
+            '--threshold',
+            type=float,
+            default=CLI_DEFAULTS['threshold'],
+            help='the percentage of docstrings that must be present to pass',
+        )
+    else:
+        if subcommand == DocstringifyRunModes.EDIT:
+            parser.add_argument(
+                '--overwrite',
+                action='store_true',
+                help='whether to overwrite the existing file with the changes',
+            )
+        parser.add_argument(
+            '--style',
+            choices=STYLES.keys(),
+            required=True,
+            help='docstring style to use',
+        )
+
+    parser.add_argument('--verbose', action='store_true', help='run in verbose mode')
+    parser.set_defaults(run=partial(_run, subcommand))
+
+    return parser
+
+
+def _create_parser() -> argparse.ArgumentParser:
+    """
+    Create an argument parser for the CLI.
+
+    Returns
+    -------
+    argparse.ArgumentParser
+        The argument parser for the CLI.
+    """
+    parser = argparse.ArgumentParser(prog=PROG, description=pkg_description)
+    parser.add_argument(
+        '--version', action='version', version=f'%(prog)s {__version__}'
+    )
+
+    subparsers = parser.add_subparsers(title='modes')
+    for mode, help_msg in [
+        (
+            DocstringifyRunModes.CHECK,
+            'use Docstringify to check whether files have the required docstrings',
+        ),
+        (
+            DocstringifyRunModes.EDIT,
+            'use Docstringify to edit files to inject docstring templates for you',
+        ),
+        (
+            DocstringifyRunModes.SUGGEST,
+            'use Docstringify to review files and suggest templates for missing docstrings',
+        ),
+    ]:
+        _populate_subparser(subparsers, mode, help_msg)
+
+    return parser
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """
     Flag missing docstrings and, optionally, generate them from signatures and
@@ -47,81 +230,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     Returns
     -------
     int
-        Exit code for the process, where non-zero values indicate errors, and ``1``
-        indicates that more than the allowed percentage of docstrings were missing.
+        Exit code for the process, where non-zero values indicate errors.
     """
-
-    parser = argparse.ArgumentParser(prog=PROG, description=pkg_description)
-    parser.add_argument('filenames', nargs='*', help='Filenames to process')
-    parser.add_argument(
-        '-v', '--verbose', action='store_true', help='Run in verbose mode'
-    )
-    parser.add_argument(
-        '--version', action='version', version=f'%(prog)s {__version__}'
-    )
-
-    run_group = parser.add_argument_group('Run options')
-    handle_missing_docstring = run_group.add_mutually_exclusive_group(required=False)
-    handle_missing_docstring.add_argument(
-        '--make-changes',
-        choices=STYLES.keys(),
-        help='Whether to insert docstring templates for items missing docstrings',
-    )
-    handle_missing_docstring.add_argument(
-        '--make-changes-inplace',
-        choices=STYLES.keys(),
-        help=(
-            'Whether to insert docstring templates for items missing docstrings, '
-            'overwriting the original file'
-        ),
-    )
-    handle_missing_docstring.add_argument(
-        '--suggest-changes',
-        choices=STYLES.keys(),
-        help='Whether to print out docstring templates for items missing docstrings',
-    )
-    run_group.add_argument(
-        '--threshold',
-        type=float,
-        default=CLI_DEFAULTS['threshold'],
-        help='The percentage of docstrings that must be present to pass',
-    )
+    parser = _create_parser()
     args = parser.parse_args(argv)
-
-    get_docstring_processor = (
-        partial(
-            DocstringTransformer,
-            converter=STYLES[style],
-            overwrite=bool(args.make_changes_inplace),
-            verbose=args.verbose,
-        )
-        if (style := args.make_changes or args.make_changes_inplace)
-        else partial(
-            DocstringVisitor,
-            converter=STYLES.get(args.suggest_changes),
-            verbose=args.verbose,
-        )
-    )
-
-    docstrings_processed = missing_docstrings = 0
-    for file in args.filenames:
-        processor = get_docstring_processor(file)
-        processor.process_file()
-        missing_docstrings += len(processor.missing_docstrings)
-        docstrings_processed += processor.docstrings_inspected
-
-    if (
-        docstrings_processed
-        and (missing_percentage := (missing_docstrings / docstrings_processed))
-        > 1 - args.threshold
-    ):
-        print(f'Missing {missing_percentage:.0%} of docstrings', file=sys.stderr)
-        print(
-            f'Your settings require {args.threshold:.0%} of docstrings to be present',
-            file=sys.stderr,
-        )
-        return 1
-    return 0
+    return args.run(args)
 
 
 if __name__ == '__main__':

--- a/src/docstringify/cli.py
+++ b/src/docstringify/cli.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
 
 
 PROG = __package__
+"""CLI name."""
+
 STYLES: dict[
     str,
     type[GoogleDocstringConverter]
@@ -32,15 +34,24 @@ STYLES: dict[
     'numpydoc': NumpydocDocstringConverter,
     'stub': StubDocstringConverter,
 }
+"""Mapping of docstring style name to the converter class (:mod:`.converters`)."""
+
 CLI_DEFAULTS = {'threshold': 1.0}
+"""CLI default values."""
 
 
 class DocstringifyRunModes(StrEnum):
     """Run modes for Docstringify's CLI."""
 
     CHECK = auto()
+    """Docstringify mode that checks for missing docstrings only."""
+
     EDIT = auto()
+    """Docstringify mode that injects templates for missing docstrings into the
+    source code."""
+
     SUGGEST = auto()
+    """Docstringify mode that suggests templates for missing docstrings."""
 
 
 def _process_files(


### PR DESCRIPTION
**Describe your changes**

- Increase minimum Python version to 3.11
- Mark existing pre-commit hook as deprecated (in the name) since it will now require a subcommand to run (meaning existing usage will break)
- Rework CLI to use subcommands for the three modes that Docstringify can be run in: check (look for missing docstrings), suggest (print templates for missing docstrings), and edit (inject docstrings templates into the code, with the option to overwrite the file). This allows the suggest and edit options to run in parallel since only the check option needs to run in serial (it needs to calculate the percentage of missing docstrings across the code base).
- Update CI workflow to test the new pre-commit hooks

**Checklist**

<!-- Place an X between the [ ] for completed tasks -->

- [x] Docstrings have been modified/created for any code changes.
- [x] All linting and formatting checks pass (see the [contributing guidelines](https://github.com/stefmolin/docstringify/blob/main/CONTRIBUTING.md) for more information).